### PR TITLE
Update GitLab URL to new location in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Development has moved to https://framagit.org/zoggy/ocaml-solid
+Development has moved to https://framagit.org/zoggy/ocaml-ldp
 
 # ocaml-solid
 Library to build LDP and SOLID applications https://github.com/solid,


### PR DESCRIPTION
As the repo has moved on the GitLab server, I thought it might be a good idea to update the link here as well.